### PR TITLE
Insert copyright notice for AGPL-3.0-only

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python
+
+# Copyright (C) 2019 Tom Hacohen
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 only.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>
+
 import os
 import sys
 


### PR DESCRIPTION
Since in the [SPDX License List](https://spdx.org/licenses/) the AGPL-3.0 is deprecated and it was not clear to me wether it is not AGPL-3.0-or-later. We cannot select AGPL-3.0-only on the Github LICENSE tab, can we?