### PR TITLE
Add env variable to change configuration file path.

### DIFF
--- a/etebase_server/settings.py
+++ b/etebase_server/settings.py
@@ -141,7 +141,12 @@ MEDIA_URL = '/user-media/'
 
 
 # Define where to find configuration files
-config_locations = ['etebase-server.ini', '/etc/etebase-server/etebase-server.ini']
+config_locations = [
+    os.environ.get('ETEBASE_EASY_CONFIG_PATH', ''),
+    'etebase-server.ini',
+    '/etc/etebase-server/etebase-server.ini',
+]
+
 # Use config file if present
 if any(os.path.isfile(x) for x in config_locations):
     config = configparser.ConfigParser()


### PR DESCRIPTION
If not set, ETEBASE_INI_PATH defaults to BASE_DIR/etebase-server.ini

As discussed on  #51 