### PR TITLE
WIP: Implement LDAP Support

### DIFF
--- a/django_etebase/app_settings.py
+++ b/django_etebase/app_settings.py
@@ -78,6 +78,34 @@ class AppSettings:
     @cached_property
     def CHALLENGE_VALID_SECONDS(self):  # pylint: disable=invalid-name
         return self._setting("CHALLENGE_VALID_SECONDS", 60)
+    
+    @cached_property
+    def USE_LDAP(self): # pylint: disable=invalid-name
+        return self._setting("USE_LDAP", False)
+
+    @cached_property
+    def LDAP_FILTER(self): # pylint: disable=invalid-name
+        return self._setting("LDAP_FILTER", "")
+
+    @cached_property
+    def LDAP_SEARCH_BASE(self): # pylint: disable=invalid-name
+        return self._setting("LDAP_SEARCH_BASE", "")
+
+    @cached_property
+    def LDAP_SERVER(self): # pylint: disable=invalid-name
+        return self._setting("LDAP_SERVER", "")
+
+    @cached_property
+    def LDAP_BIND_DN(self): # pylint: disable=invalid-name
+        return self._setting("LDAP_BIND_DN", "")
+
+    @cached_property
+    def LDAP_BIND_PASSWORD(self): # pylint: disable=invalid-name
+        return self._setting("LDAP_BIND_PW", "")
+
+    @cached_property
+    def LDAP_SEARCH_BASE(self): # pylint: disable=invalid-name
+        return self._setting("LDAP_SEARCH_BASE", "")
 
 
 app_settings = AppSettings('ETEBASE_')

--- a/django_etebase/ldap.py
+++ b/django_etebase/ldap.py
@@ -1,0 +1,45 @@
+import logging
+
+from . import app_settings
+
+import ldap
+
+class LDAPConnection:
+    __instance__ = None
+
+    @staticmethod
+    def get_instance():
+        '''To get a Singleton'''
+        if not LDAPConnection.__instance__:
+            return LDAPConnection()
+        else:
+            return LDAPConnection.__instance__
+
+    def __init__(self):
+        # Pull settings from django.conf.settings
+        # NOTE: We assume that settings.USE_LDAP is True
+        self.__ldap_connection = ldap.initialize(app_settings.LDAP_SERVER)
+        try:
+            self.__ldap_connection.simple_bind_s(app_settings.LDAP_BIND_DN,
+                                                 app_settings.LDAP_BIND_PASSWORD)
+        except ldap.LDAPError as err:
+            logging.error(f'LDAP Error occuring during initialization: {err.desc}')
+
+    def has_user(self, username):
+        '''
+        Since we don't care about the password and so authentication
+        another way, all we care about is whether the user exists.
+        '''
+        filterstr = app_settings.LDAP_FILTER.replace('%s', username)
+        try:
+            result = self.__ldap_connection.search_s(app_settings.LDAP_SEARCH_BASE,
+                                                     ldap.SCOPE_SUBTREE,
+                                                     filterstr=filterstr)
+        except ldap.NO_RESULTS_RETURNED:
+            # We handle the specific error first and the the generic error, as
+            # we may expect ldap.NO_RESULTS_RETURNED, but not any other error
+            return False
+        except ldap.LDAPError as err:
+            logging.error(f'Error occured while performing an LDAP query: {err.desc}')
+            return False
+        return len(result) == 1

--- a/django_etebase/utils.py
+++ b/django_etebase/utils.py
@@ -2,6 +2,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 
 from . import app_settings
+from .ldap import LDAPConnection
 
 
 User = get_user_model()
@@ -15,6 +16,11 @@ def get_user_queryset(queryset, view):
 
 
 def create_user(*args, **kwargs):
+    # Check if the LDAP query returns exactly one user
+    if app_settings.USE_LDAP:
+        if not LDAPConnection.get_instance().has_user(kwargs['username']):
+            raise PermissionDenied('User is not listed in the LDAP registry.')
+
     custom_func = app_settings.CREATE_USER_FUNC
     if custom_func is not None:
         return custom_func(*args, **kwargs)

--- a/etebase_server/settings.py
+++ b/etebase_server/settings.py
@@ -164,6 +164,17 @@ if any(os.path.isfile(x) for x in config_locations):
     if 'database' in config:
         DATABASES = { 'default': { x.upper(): y for x, y in config.items('database') } }
 
+    if 'ldap' in config:
+        ldap = config['ldap']
+        ETEBASE_USE_LDAP = True
+        ETEBASE_LDAP_SERVER = ldap.get('server', '')
+        ETEBASE_LDAP_SEARCH_BASE = ldap.get('search_base', '')
+        ETEBASE_LDAP_FILTER = ldap.get('filter', '')
+        ETEBASE_LDAP_BIND_DN = ldap.get('bind_dn', '')
+        ETEBASE_LDAP_BIND_PW = ldap.get('bind_pw', '')
+    else:
+        ETEBASE_USE_LDAP = False
+
 ETEBASE_API_PERMISSIONS = ('rest_framework.permissions.IsAuthenticated', )
 ETEBASE_API_AUTHENTICATORS = ('django_etebase.token_auth.authentication.TokenAuthentication',
                               'rest_framework.authentication.SessionAuthentication')


### PR DESCRIPTION
This WIP PR (fixed #53) adds support for optionally adding LDAP into the login and registration procedure by looking the user up in
the LDAP directory to decide whether to proceed with the login/registration.

While the login code is tested and working, the registration code is untested.

A question that was brought up in #53 is how to deal with a user that is logged in but whose access in LDAP is then
revoked. I am unsure how other applications do this. My guess is that they wait until the session of the user expires and the user
has to reauthenticate. But since tokens appear to live for ~30 days this might not work. The most elegant solution would probably be to cache the result of the user lookup for some time and use this on every authenticated API path (as suggested in #53).