### PR TITLE
Create a testing docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+/db.sqlite3*
+Session.vim
+/local_settings.py
+.venv
+/assets
+/logs
+/.coverage
+/tmp
+/media
+
+__pycache__
+.*.swp
+
+/.*
+
+/sandbox

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ Here are the update steps:
 4. Run the migration tool to migrate all of your data.
 5. Add your new EteSync 2.0 accounts to all of your devices.
 
+# Testing
+
+Docker images named `etesync/test-server:<version>` and `:latest` are available for testing etesync clients.
+This docker image starts a server on port 3735 that supports user signup (without email confirmation), is in debug mode (thus supporting the reset endpoint), and stores its data locally.
+It is in no way suitable for production usage, but is able to start up quickly and makes a good component of CI for etesync clients and users of those clients.
+
 # License
 
 Etebase is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation. See the [LICENSE](./LICENSE) for more information.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+# Build the `test-server` image, which runs the server in a simple configuration
+# designed to be used in tests, based on the current git revision.
+
+TAG="${1:-latest}"
+
+echo "Building working copy to etesync/test-server:${TAG}"
+
+ETESYNC_VERSION=$(git describe --tags)
+
+docker build \
+    --build-arg ETESYNC_VERSION=${ETESYNC_VERSION} \
+    -t etesync/test-server:${TAG} \
+    -f docker/test-server/Dockerfile \
+    .

--- a/docker/test-server/Dockerfile
+++ b/docker/test-server/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.9.0-alpine
+
+ARG ETESYNC_VERSION
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_NO_CACHE_DIR=1
+
+# install packages and pip requirements first, in a single step,
+COPY /requirements.txt /requirements.txt
+RUN set -ex ;\
+    apk add libpq postgresql-dev --virtual .build-deps coreutils gcc libc-dev libffi-dev make ;\
+    pip install -U pip ;\
+    pip install --no-cache-dir --progress-bar off -r /requirements.txt ;\
+    apk del .build-deps make gcc coreutils ;\
+    rm -rf /root/.cache
+
+COPY . /app
+
+RUN set -ex ;\
+    mkdir -p /data/static /data/media ;\
+    cd /app ;\
+    mkdir -p /etc/etebase-server ;\
+    cp docker/test-server/etebase-server.ini /etc/etebase-server ;\
+    sed -e '/ETEBASE_CREATE_USER_FUNC/ s/^#*/#/' -i /app/etebase_server/settings.py ;\
+    chmod +x docker/test-server/entrypoint.sh
+
+# this is a test image and should start up quickly, so it starts with the DB
+# and static data already fully set up.
+RUN set -ex ;\
+    cd /app ;\
+    python manage.py migrate ;\
+    python manage.py collectstatic --noinput
+
+ENV ETESYNC_VERSION=${ETESYNC_VERSION}
+VOLUME /data
+EXPOSE 3735
+
+ENTRYPOINT ["/app/docker/test-server/entrypoint.sh"]

--- a/docker/test-server/entrypoint.sh
+++ b/docker/test-server/entrypoint.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+echo "Running etesync test server ${ETESYNC_VERSION}"
+
+cd /app
+uvicorn etebase_server.asgi:application --host 0.0.0.0 --port 3735

--- a/docker/test-server/etebase-server.ini
+++ b/docker/test-server/etebase-server.ini
@@ -1,0 +1,12 @@
+[global]
+secret_file = secret.txt
+debug = true
+static_root = /data/static
+media_root = /data/media
+
+[allowed_hosts]
+allowed_host1 = *
+
+[database]
+engine = django.db.backends.sqlite3
+name = /db.sqlite3

--- a/etebase_server/settings.py
+++ b/etebase_server/settings.py
@@ -166,8 +166,8 @@ if any(os.path.isfile(x) for x in config_locations):
 ETEBASE_CREATE_USER_FUNC = "django_etebase.utils.create_user_blocked"
 
 # Efficient file streaming (for large files)
-SENDFILE_BACKEND = "django_etebase.sendfile.backends.simple"
-SENDFILE_ROOT = MEDIA_URL
+SENDFILE_BACKEND = "etebase_fastapi.sendfile.backends.simple"
+SENDFILE_ROOT = MEDIA_ROOT
 
 # Make an `etebase_server_settings` module available to override settings.
 try:


### PR DESCRIPTION
Fixes #94.

I've temporarily pushed this image to `djmitche/etesync-test-server:0.7.0`.  I'll put up a patch shortly to etebase-go to make its test use this image, to demonstrate that it works.