### PR TITLE
Remove port from host_from_request check

### DIFF
--- a/etebase_fastapi/routers/authentication.py
+++ b/etebase_fastapi/routers/authentication.py
@@ -161,7 +161,7 @@ def validate_login_request(
         raise HttpError("challenge_expired", "Login challenge has expired")
     elif challenge_data["userId"] != user.id:
         raise HttpError("wrong_user", "This challenge is for the wrong user")
-    elif not settings.DEBUG and validated_data.host.split(":", 1)[0] != host_from_request:
+    elif not settings.DEBUG and validated_data.host.split(":", 1)[0] != host_from_request.split(":", 1)[0]:
         raise HttpError(
             "wrong_host", f'Found wrong host name. Got: "{validated_data.host}" expected: "{host_from_request}"'
         )


### PR DESCRIPTION
This strips the port from the client requests, comparing only the hostnames or IP addresses, and should alleviate nonstandard port and initial testing issues.  Tested on Linux, Mac, and Android clients.  Closes #105.

Code is from this comment:

https://github.com/etesync/server/issues/66#issuecomment-731215345