### PR TITLE
fix(etebase_fastapi): fix crash on shutdown

### DIFF
--- a/etebase_fastapi/redis.py
+++ b/etebase_fastapi/redis.py
@@ -15,7 +15,7 @@ class RedisWrapper:
             self.redis = await aioredis.create_redis_pool(self.redis_uri)
 
     async def close(self):
-        if self.redis is not None:
+        if hasattr(self, "redis"):
             self.redis.close()
             await self.redis.wait_closed()
 


### PR DESCRIPTION
`self.redis` isn't `None`, it's actually unset, so accessing it results in an exception:

```
ERROR:    Traceback (most recent call last):
  File "./.venv/lib/python3.9/site-packages/starlette/routing.py", line 624, in lifespan
    await receive()
  File "./.venv/lib/python3.9/site-packages/starlette/routing.py", line 521, in __aexit__
    await self._router.shutdown()
  File "./.venv/lib/python3.9/site-packages/starlette/routing.py", line 608, in shutdown
    await handler()
  File "./etebase_fastapi/main.py", line 72, in on_shutdown
    await redisw.close()
  File "./etebase_fastapi/redis.py", line 18, in close
    if self.redis is not None:
AttributeError: 'RedisWrapper' object has no attribute 'redis'
```