### PR TITLE
fix(manage.py): fix shebang to work on Debian-based systems

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Django's command-line utility for administrative tasks."""
 import os
 import sys


### PR DESCRIPTION
In Debian, `/usr/bin/python` is python 2.7.