### PR TITLE
config: allow specifying engine-specific database options

### DIFF
--- a/etebase-server.ini.example
+++ b/etebase-server.ini.example
@@ -18,3 +18,6 @@ allowed_host1 = example.com
 [database]
 engine = django.db.backends.sqlite3
 name = db.sqlite3
+
+[database-options]
+; Add engine-specific options here, such as postgresql parameter key words

--- a/etebase_server/settings.py
+++ b/etebase_server/settings.py
@@ -164,6 +164,9 @@ if any(os.path.isfile(x) for x in config_locations):
     if "database" in config:
         DATABASES = {"default": {x.upper(): y for x, y in config.items("database")}}
 
+    if "database-options" in config:
+        DATABASES["default"]["OPTIONS"] = config["database-options"]
+
 ETEBASE_CREATE_USER_FUNC = "django_etebase.utils.create_user_blocked"
 
 # Efficient file streaming (for large files)


### PR DESCRIPTION
These are required to e.g. use PostgreSQL client certificates using `sslcert=`/`sslkey=`.