### PR TITLE
fix: use django.urls.re_path instead of deprecated django.conf.urls.url

### DIFF
--- a/etebase_server/urls.py
+++ b/etebase_server/urls.py
@@ -2,7 +2,7 @@ import os
 
 from django.conf import settings
 from django.contrib import admin
-from django.urls import path, re_path
+from django.urls import path
 from django.views.generic import TemplateView
 from django.views.static import serve
 from django.contrib.staticfiles import finders
@@ -11,14 +11,3 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", TemplateView.as_view(template_name="success.html")),
 ]
-
-if settings.DEBUG:
-
-    def serve_static(request, path):
-        filename = finders.find(path)
-        dirname = os.path.dirname(filename)
-        basename = os.path.basename(filename)
-
-        return serve(request, basename, dirname)
-
-    urlpatterns += [re_path(r"^static/(?P<path>.*)$", serve_static)]

--- a/etebase_server/urls.py
+++ b/etebase_server/urls.py
@@ -1,7 +1,6 @@
 import os
 
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin
 from django.urls import path, re_path
 from django.views.generic import TemplateView
@@ -9,7 +8,7 @@ from django.views.static import serve
 from django.contrib.staticfiles import finders
 
 urlpatterns = [
-    url(r"^admin/", admin.site.urls),
+    path("admin/", admin.site.urls),
     path("", TemplateView.as_view(template_name="success.html")),
 ]
 


### PR DESCRIPTION
`django.conf.urls.url` has been removed in django version 4.

Fixes #119.