### PR TITLE
fix: remove deprecated argument "providing_args" from Signal()

### DIFF
--- a/django_etebase/signals.py
+++ b/django_etebase/signals.py
@@ -1,3 +1,4 @@
 from django.dispatch import Signal
 
-user_signed_up = Signal(providing_args=["request", "user"])
+# Provides arguments "request" and "user"
+user_signed_up = Signal()


### PR DESCRIPTION
From the source:

> The providing_args argument is deprecated. As it is purely
> documentational, it has no replacement. If you rely on this
> argument as documentation, you can move the text to a code
> comment or docstring.