### PR TITLE
fix(testserver): store database in /data partition

### DIFF
--- a/docker/test-server/etebase-server.ini
+++ b/docker/test-server/etebase-server.ini
@@ -9,4 +9,4 @@ allowed_host1 = *
 
 [database]
 engine = django.db.backends.sqlite3
-name = /db.sqlite3
+name = /data/db.sqlite3


### PR DESCRIPTION
This allows testing version migrations by simply mounting the volume into a container with a different image.