### PR TITLE
Update pyyaml from 6.0 to 6.0.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ python-dotenv==0.21.0
     # via uvicorn
 pytz==2022.6
     # via django
-pyyaml==6.0
+pyyaml==6.0.1
     # via uvicorn
 redis==4.4.0
     # via -r requirements.in/base.txt


### PR DESCRIPTION
Hi, I ran into an `AttributeError: cython_sources` originating from pyyaml when building the server on OpenBSD 7.4 w/ Python 3.10.13, error log below. This seems to be caused by Cython (see [https://github.com/yaml/pyyaml/issues/601](https://github.com/yaml/pyyaml/issues/601)) and updating pyyaml to 6.0.1 resolves the issue.

<details>
  <summary>Errors from failed  pip install -r requirements.txt</summary>

```
Collecting pyyaml==6.0 (from -r requirements.txt (line 43))
  Using cached PyYAML-6.0.tar.gz (124 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [48 lines of output]
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/var/etebase/.venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/var/etebase/.venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/var/etebase/.venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 355, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 325, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 341, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 989, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 318, in run
          self.find_sources()
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 326, in find_sources
          mm.run()
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 548, in run
          self.add_defaults()
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 586, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/command/sdist.py", line 113, in add_defaults
          super().add_defaults()
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "<string>", line 204, in get_source_files
        File "/tmp/pip-build-env-7ju3vhow/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```
</details>