### PR TITLE
Fix django version specifier

### DIFF
--- a/requirements.in/base.txt
+++ b/requirements.in/base.txt
@@ -1,4 +1,4 @@
-django>=4.0<5.0
+django>=4.0,<5.0
 msgpack
 pynacl
 fastapi


### PR DESCRIPTION
This errors out when building. I've patched this in Nixpkgs, but an upstream patch is much better for others. See https://github.com/NixOS/nixpkgs/pull/316984 for the same patch in the nix package.