### PR TITLE
Fixes "Origin checking failed - https://.. does not match any trusted origins"

### DIFF
--- a/etebase_server/settings.py
+++ b/etebase_server/settings.py
@@ -162,6 +162,8 @@ if any(os.path.isfile(x) for x in config_locations):
 
     if "allowed_hosts" in config:
         ALLOWED_HOSTS = [y for x, y in config.items("allowed_hosts")]
+        CSRF_TRUSTED_ORIGINS = ["https://" + y for x, y in config.items("allowed_hosts")] + \
+                               ["http://" + y for x, y in config.items("allowed_hosts")]
 
     if "database" in config:
         DATABASES = {"default": {x.upper(): y for x, y in config.items("database")}}


### PR DESCRIPTION
Since some recent upgrade, I'm not able to login to the admin page of etesync (`/admin/login/`), because the CSRF check fails.


After adding `CSRF_TRUSTED_ORIGINS = ['https://my-domain.com']`, it works.
According to the [docs](https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins), this setting is required in addition to `ALLOWED_HOSTS`.