### PR TITLE
Allow etebase server to run on non standard ports

### DIFF
--- a/etebase-server.ini.example
+++ b/etebase-server.ini.example
@@ -15,6 +15,10 @@ media_root = /path/to/media
 [allowed_hosts]
 allowed_host1 = example.com
 
+[ports]
+;http_port = 8000
+;https_port = 8043
+
 [database]
 engine = django.db.backends.sqlite3
 name = db.sqlite3

--- a/etebase_server/settings.py
+++ b/etebase_server/settings.py
@@ -163,10 +163,18 @@ if any(os.path.isfile(x) for x in config_locations):
         ETEBASE_REDIS_URI = section.get("redis_uri")
 
     if "allowed_hosts" in config:
+        if "ports" in config and "https_port" in config["ports"]:
+            https_port = ":" + config["ports"]["https_port"]
+        else:
+            https_port = ""
+        if "ports" in config and "http_port" in config["ports"]:
+            http_port = ":" + config["ports"]["http_port"]
+        else:
+            http_port = ""
         ALLOWED_HOSTS = [y for x, y in config.items("allowed_hosts")]
-        CSRF_TRUSTED_ORIGINS = ["https://" + y for x, y in config.items("allowed_hosts")] + \
-                               ["http://" + y for x, y in config.items("allowed_hosts")]
-
+        CSRF_TRUSTED_ORIGINS = ["https://" + y + https_port for x, y in config.items("allowed_hosts")] + \
+                               ["http://" + y + http_port for x, y in config.items("allowed_hosts")]
+    
     if "database" in config:
         DATABASES = {"default": {x.upper(): y for x, y in config.items("database")}}
 


### PR DESCRIPTION
When the `nginx` is serving pages on a non standard `http` or `https` port, an attempt to login at the admin page leads to a 403 error   
`CSRF verification failed. Request aborted.` 

With `debug = true`, the detailed error is   
`Origin checking failed  xxx does not match any trusted origins`

The solution is to add the non standard port to the `url`  in `CSRF_TRUSTED_ORIGINS` in `settings.py`. To accomplish this, this pull request 

1. Adds a new section `ports` to the example `etebase-server.ini` where the user can specify the non standard port(s).
2. Adds code to `settings.py` to include any non standard port configured as above to the `urls` in `CSRF_TRUSTED_ORIGINS`

Merging this pull request would close [Issue 189](https://github.com/etesync/server/issues/189)